### PR TITLE
fixes for val

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## UNRELEASED
+
+- Replaced `defaultLocale` option with `mapLocale`, which defaults to mapping `default` to `en`, as that's the right thing to do for projects with or without workflow in most cases, and allows for a broader remapping if needed. Clarified documentation on how this works and implemented it for the case where workflow is enabled for the first time.
+- The `visibility` property is now set, as required in A3. If `published` was `true` it is set to `public`, otherwise to `loginRequired`. While the two features are not identical this does a good job of avoiding premature public access to migrated content.
+- Don't crash if the workflow module is enabled with no `prefixes` option.
+- Supply an `_id` for every exported `area`.
+
 ## 3.0.0-alpha (2021-09-23)
 
 - First alpha test release.

--- a/README.md
+++ b/README.md
@@ -35,16 +35,18 @@ modules: {
 
 Then create `lib/modules/@apostrophecms/content-upgrader/index.js`. Here you can optionally address any content transformations and set the default locale, which is important *even if you have no immediate plans to localize your site in other languages.*
 
-### Setting the default locale
+### Mapping locales
 
-In `lib/modules/@apostrophecms/content-upgrader/index.js`, be sure to set the default locale name to match your A3 project. Otherwise your site may appear to have no content after the upgrade.
+In A3, "workflow" is always present, and the default locale is `en`. In A2, the default locale of the workflow module is `default` if no other configuration is done.
 
-If no locale configuration at all is done in your A3 project, it will be `en`, so that is the default here as well if you do not specify otherwise.
+By default, this module's `mapLocale` option will do the right thing to ensure that typical A2 content is reachable after the migration to A3, but you can adjust this option if needed. here is the default setting:
 
 ```javascript
 // In lib/modules/@apostrophecms/content-upgrader/index.js
 module.exports = {
-  defaultLocale: 'fr'
+  mapLocales: {
+    default: 'en'
+  }
 };
 ```
 


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

**Val: to help you move things along this morning, please merge this yourself if you are satisfied.**

- Replaced `defaultLocale` option with `mapLocale`, which defaults to mapping `default` to `en`, as that's the right thing to do for projects with or without workflow in most cases, and allows for a broader remapping if needed. Clarified documentation on how this works and implemented it for the case where workflow is enabled for the first time.
- The `visibility` property is now set, as required in A3. If `published` was `true` it is set to `public`, otherwise to `loginRequired`. While the two features are not identical this does a good job of avoiding premature public access to migrated content.
- Don't crash if the workflow module is enabled with no `prefixes` option.
- Supply an `_id` for every exported `area`.

## What are the specific steps to test this change?

Successful content upgrader run.

## What kind of change does this PR introduce?
*(Check at least one)*

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [X] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [X] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
