### PR TITLE
do not copy the safe since we do not copy the users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - The `visibility` property is now set, as required in A3. If `published` was `true` it is set to `public`, otherwise to `loginRequired`. While the two features are not identical this does a good job of avoiding premature public access to migrated content.
 - Don't crash if the workflow module is enabled with no `prefixes` option.
 - Supply an `_id` for every exported `area`.
+- As the content upgrader intentionally does not copy user and group pieces, it should not copy the `aposUsersSafe` collection from 2.x to 3.x, either.
 
 ## 3.0.0-alpha (2021-09-23)
 

--- a/index.js
+++ b/index.js
@@ -53,7 +53,6 @@ module.exports = {
       await self.client.connect();
       self.docs = self.client.db().collection('aposDocs');
       self.attachments = self.client.db().collection('aposAttachments');
-      self.usersSafe = self.client.db().collection('aposUsersSafe');
       const count = await self.docs.countDocuments({});
       if (count) {
         if (!self.apos.argv.drop) {
@@ -68,7 +67,6 @@ module.exports = {
       await self.connectToNewDb();
       await self.upgradeDocsPass();
       await self.rewriteDocsJoinIdsPass();
-      await self.upgradeUsersSafe();
       await self.upgradeAttachments();
       await self.report();
     };
@@ -95,12 +93,6 @@ module.exports = {
         attachment.archivedDocIds = attachment.trashDocIds;
         delete attachment.trashDocIds;
         await self.attachments.insertOne(attachment);
-      });
-    };
-    self.upgradeUsersSafe = async () => {
-      await self.usersSafe.deleteMany({});
-      await self.apos.migrations.each(self.apos.users.safe, {}, 5, async userSafe => {
-        await self.usersSafe.insertOne(userSafe);
       });
     };
     self.upgradeDoc = async doc => {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Should not copy the safe since we do not copy the users

## What are the specific steps to test this change?

Nothing in aposUsersSafe after the migration (assuming an empty A3 db to start)

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
