### PR TITLE
fix rich text permalink ids in migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0-beta.7 (2022-12-14)
+
+- Support for migrating rich text permalinks.
+
 ## 3.0.0-beta.6 (2022-12-12)
 
 - Safer migration of site pieces, in case that piece type name is used for something else in a non-multisite project.

--- a/index.js
+++ b/index.js
@@ -406,6 +406,26 @@ module.exports = {
         }, doc);
       }
       function rewrite(object) {
+        if (object.type === '@apostrophecms/rich-text') {
+          // Handle rich text permalinks
+          object.permalinkIds = [];
+          object.content = (object.content || '').replace(/"#apostrophe-permalink-[^"?]*?\?/g, (match) => {
+            const matches = match.match(/apostrophe-permalink-(.*)\?/);
+            if (matches) {
+              const id = self.a2ToA3Ids.get(matches[1]);
+              if (id) {
+                object.permalinkIds.push(id);
+                console.log(`rewrote permalink now points to ${id}`);
+                return `"#apostrophe-permalink-${id}?`;
+              } else {
+                // No match, leave it alone
+                return match;
+              }
+            }
+          });
+          return;
+        }
+        // Handle other references to doc ids anywhere we find them
         let modified = false;
         const patchKeys = {};
         for (const key of Object.keys(object)) {          

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apostrophecms/content-upgrader",
-  "version": "3.0.0-beta.6",
+  "version": "3.0.0-beta.7",
   "description": "Upgrades Apostrophe 2.x databases to be compatible with Apostrophe 3.x",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Has to point to aposDocId. This has to be done late when the ids are known, so we can't just put it in a default transformer for the widget type.

## What are the specific steps to test this change?

I tested it with the Utah database and successfully migrated their zillions of permalinks.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [ ] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
