### PR TITLE
hotfix for issue with root page of the archive being deleted from published mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.0-beta.9 (2023-02-02)
+
+- Hotfix: do not delete the published mode of the /archive page when exporting, it is a special exception to the rule that archived documents have no published mode
+
 ## 3.0.0-beta.8 (2023-02-01)
 
 - Remove the published version of draft documents that are archived (in A3, an archived document exists only as a draft).

--- a/index.js
+++ b/index.js
@@ -118,8 +118,10 @@ module.exports = {
 
         const [ draft ] = await self.docs.find({ _id: doc._id.replace('published', 'draft') }).toArray();
 
-        if (draft.archived) {
-          // Remove the published version of draft documents that are archived:
+        if (draft.archived && (draft.parkedId !== 'archive')) {
+          // Remove the published version of draft documents that are archived,
+          // except the root archive page which by convention exists in the
+          // published locale
           await self.docs.deleteMany({ _id: doc._id });
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@apostrophecms/content-upgrader",
-  "version": "3.0.0-beta.8",
+  "version": "3.0.0-beta.9",
   "description": "Upgrades Apostrophe 2.x databases to be compatible with Apostrophe 3.x",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This hotfix is needed to get UT out the door and may also impact iC export, and Etienne is out tomorrow. See comments.