### PR TITLE
support for partial migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## UNRELEASED
+
+- Added the `--only=type1,type2,...` option to migrate only certain A2 doc types and the attachments they reference. Include `apostrophe-image` (and/or `apostrophe-file`) in the list if you want the corresponding media to come across.
+- Added the `--related-images` option to migrate only the images actually referenced by the migrated content (one hop, resolved against the A4-form content), rather than every image. Works on its own or together with `--only`.
+- Added the `--merge` option to add the upgraded content to an existing A4 database instead of insisting on `--drop`. Existing content is preserved and new content is inserted alongside it.
+- Added the `--replace` option, which upserts documents and attachments (overwriting any with matching ids) rather than inserting them, so re-running an upgrade does not fail with duplicate key errors. `--replace` implies `--merge`.
+- Added the `--copy-media` option (which requires `--a4-dir`) to copy the physical media files of the migrated attachments into the A4 project, respecting `--only` and `--related-images`. Assumes media is stored locally under `public/uploads/attachments`; it does not use uploadfs and so does not handle remote (e.g. S3) storage.
+
 ## 1.1.2 (2026-04-01)
 
 - The `--drop` option now drops all existing collections in the `a4-db`, as it always promised to do. Previously

--- a/README.md
+++ b/README.md
@@ -205,20 +205,71 @@ node app @apostrophecms/content-upgrader:upgrade --a3-db=mongodb://localhost:270
 
 The media files themselves don't need to change in the transition to A4.
 
-So you can manually copy the `public/uploads` folder from the A2 project to the A4 project, or use `rsync`. If you are using uploadfs to store your media in S3 your procedure will vary.
+You can copy the `public/uploads` folder from the A2 project to the A4 project manually, or use `rsync`. If you are using uploadfs to store your media in S3 your procedure will vary.
 
-This tool may automatically copy the `public/uploadfs` folder in a future update.
+Alternatively, pass `--copy-media` (together with `--a4-dir`) and this tool will copy the media for the migrated attachments for you. This is especially convenient with `--only` and `--related-images`, because only the media for the attachments actually migrated is copied. See the options below.
 
 ## Options
 
 ### `--a4-db`
 
-**Required.** This must be the MongoDB URI of your new A3/A4 project. It will be **cleared and overwritten**. Currently there is no support for merging upgrade content with an existing A4 database.
+**Required.** This must be the MongoDB URI of your new A3/A4 project. By default it will be **cleared and overwritten**. See `--merge` and `--replace` below if you want to add to an existing A4 database instead.
 
 ### `--drop`
 
 **Optional.** If at least one Apostrophe doc exists in the new A4 database, the task will exit with an error message unless this option is passed. If the option is passed, existing collections are dropped to start
-from scratch.
+from scratch. Cannot be combined with `--merge` or `--replace`.
+
+### `--only=type1,type2,...`
+
+**Optional.** Migrate **only** the specified doc types, and only the attachments referenced by those docs. The values are the **A2** `type` names (the same names you would use as keys in `mapDocTypes`), separated by commas.
+
+This is useful for re-migrating a single piece type into an existing A4 database without redoing everything. Combine it with `--merge` or `--replace`, since the target database will already contain data.
+
+🎩 **Attachments (images, files, etc.) are only migrated if a migrated doc references them.** For example, if you want your images to come across, include `apostrophe-image` in the list: `--only=apostrophe-image,article`. The tool does not try to guess which other types your selected types depend on. (See `--related-images` below for a way to bring across just the images your content actually uses.)
+
+Note that relationships/joins pointing to doc types you did **not** include cannot be rewritten to their new ids, because those docs are not part of this migration.
+
+### `--related-images`
+
+**Optional.** Instead of migrating every `apostrophe-image` piece, migrate **only the images actually referenced by the other content being migrated**, along with their attachments. This is handy when your media library contains far more images than your live content uses.
+
+It works on its own — `--related-images` performs a normal full migration but leaves out images nothing refers to — and it composes with `--only`:
+
+* `--only=article,apostrophe-image` migrates every article **and every image**.
+* `--only=article --related-images` migrates every article and **only the images those articles reference** (you do not include `apostrophe-image` yourself; it is handled for you).
+
+Only images **directly** referenced by a migrated doc are included (one hop). If an article references some other piece that in turn references an image, and that piece is not itself migrated, its image will not be pulled in. References are resolved against the migrated, A4-form content, so for a legacy `apostrophe-images` slideshow that is reduced to a single-image `@apostrophecms/image` widget, only that one surviving image is considered "referenced".
+
+### `--merge`
+
+**Optional.** Add the upgraded content to the existing A4 database instead of insisting on `--drop`. Existing documents and attachments are left untouched, and the newly upgraded content is inserted alongside them.
+
+If a document or attachment being inserted has the same `_id` as one that already exists, MongoDB will report a duplicate key error. Use `--replace` instead if you want matching documents to be overwritten.
+
+### `--replace`
+
+**Optional.** Like `--merge`, but instead of inserting documents and attachments, it **upserts** them: any existing document or attachment with a matching `_id` is overwritten, and there is no duplicate key error. `--replace` implies `--merge`, so you do not need to pass both.
+
+This is the option to use when re-running an upgrade for a subset of your content, for example `--only=apostrophe-image,article --replace`.
+
+### `--a4-dir=/path/to/a4/project`
+
+**Optional.** The root directory of your new A4 project. Only used by `--copy-media`, to locate the destination `public/uploads/attachments` folder.
+
+### `--copy-media`
+
+**Optional.** Physically copy the media files for the migrated attachments from this A2 project to the A4 project. **Requires `--a4-dir`.**
+
+Only the files for the attachments actually migrated are copied, so this respects `--only` and `--related-images` — a targeted upgrade copies only the media it needs.
+
+🎩 **This option assumes your media is stored locally**, under `public/uploads/attachments`, in both projects. It copies files directly and does **not** go through uploadfs, so it is not suitable for media stored remotely (for example in S3); copy that by your own means. Any migrated attachment whose files are not found locally is reported at the end.
+
+```
+node app @apostrophecms/content-upgrader:upgrade \
+  --a4-db=mongodb://localhost:27017/your-new-database-name \
+  --a4-dir=/path/to/your/a4/project --copy-media
+```
 
 ## Next steps
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 const { findSourceMap } = require('module');
 const { MongoClient } = require('mongodb');
+const fsp = require('fs').promises;
+const path = require('path');
+
+// The A2 `type` (name option) of image pieces, mapped to `@apostrophecms/image`
+// in A4. Used by --related-images to find and skip/collect image docs.
+const A2_IMAGE_TYPE = 'apostrophe-image';
 
 module.exports = {
   mapLocales: {
@@ -61,22 +67,76 @@ module.exports = {
       self.attachments = self.client.db().collection('aposAttachments');
       const count = await self.docs.countDocuments({});
       if (count) {
-        if (!self.apos.argv.drop) {
-          fail('Your new A4 database already contains data.\nIf you are comfortable DELETING that data for a fresh upgrade attempt,\nrun again with: --drop');
-        }
-        const db = self.client.db();
-        const collections = await db.listCollections().toArray();
-        for (const collection of collections) {
-          await db.collection(collection.name).drop();
+        if (self.merge) {
+          // --merge (or --replace, which implies it): leave the existing
+          // content in place and add the upgraded content alongside it.
+        } else if (self.apos.argv.drop) {
+          const db = self.client.db();
+          const collections = await db.listCollections().toArray();
+          for (const collection of collections) {
+            await db.collection(collection.name).drop();
+          }
+        } else if (self.only) {
+          fail('Your new A4 database already contains data, but you are using --only,\nso adding to it may make sense. Add --merge to insert the selected types,\nor --replace to also overwrite existing docs of those types.');
+        } else {
+          fail('Your new A4 database already contains data.\nIf you are comfortable DELETING that data for a fresh upgrade attempt,\nrun again with: --drop.\nTo instead add to the existing content, use --merge (or --replace to\noverwrite docs with matching ids).');
         }
       }
     };
     self.addUpgradeTask = () => {
       self.addTask('upgrade', 'Upgrade content for A4', self.upgradeTask);
     };
+    self.parseOptions = (argv) => {
+      self.replace = !!argv.replace;
+      // --replace implies --merge: upserting into a database only makes sense
+      // when we are keeping the content that is already there
+      self.merge = !!argv.merge || self.replace;
+      if (self.merge && argv.drop) {
+        fail('The --drop option cannot be combined with --merge or --replace.\n--drop wipes the database; the others add to or overwrite existing content.');
+      }
+      if (argv.only === true) {
+        fail('The --only option requires a comma-separated list of A2 doc types,\ne.g. --only=apostrophe-image,article');
+      }
+      self.only = (typeof argv.only === 'string' && argv.only.trim().length)
+        ? argv.only.split(',').map(type => type.trim()).filter(type => type.length)
+        : null;
+      // Migrate only the image docs actually referenced by the other migrated
+      // content, instead of every image. Composes with --only.
+      self.relatedImages = !!argv['related-images'];
+      // Optionally copy the physical media (public/uploads/attachments) of the
+      // migrated attachments into the A4 project directory. Assumes local media.
+      self.copyMedia = !!argv['copy-media'];
+      self.a4Dir = (typeof argv['a4-dir'] === 'string' && argv['a4-dir'].trim().length)
+        ? argv['a4-dir'].trim()
+        : null;
+      if (self.copyMedia && !self.a4Dir) {
+        fail('The --copy-media option requires --a4-dir=/path/to/your/a4/project.');
+      }
+    };
     self.upgradeTask = async (apos, argv) => {
+      self.parseOptions(argv);
+      if (self.only) {
+        console.log(`Migrating only these doc types (and their attachments):\n  ${self.only.join('\n  ')}\n`);
+      }
+      if (self.merge) {
+        console.log(self.replace
+          ? 'Merging into existing content; docs and attachments with matching ids will be replaced.\n'
+          : 'Merging into existing content; existing content is preserved.\n');
+      }
+      if (self.relatedImages) {
+        console.log('Migrating only the images referenced by the migrated content (--related-images).\n');
+      }
       await self.connectToNewDb();
+      if (self.relatedImages) {
+        await self.prepareRelatedImages();
+      }
       await self.upgradeDocsPass();
+      if (self.relatedImages) {
+        // Must run after the content is migrated (so we know which images it
+        // references) but before the id-rewrite pass (so those images are in
+        // a2ToA4Ids when references to them are rewritten).
+        await self.upgradeRelatedImages();
+      }
       await self.rewriteDocsJoinIdsPass();
       await self.removeSuperfluousDocs();
       await self.upgradeAttachments();
@@ -84,8 +144,22 @@ module.exports = {
       await self.report();
     };
     self.upgradeDocsPass = async () => {
-      await self.docs.deleteMany({});
-      const cursor = self.apos.docs.db.find({}).sort({
+      if (!self.merge) {
+        await self.docs.deleteMany({});
+      }
+      let criteria = {};
+      if (self.only) {
+        // With --related-images, images are handled by their own pass, so drop
+        // apostrophe-image from the list even if the user included it.
+        const types = self.relatedImages
+          ? self.only.filter(type => type !== A2_IMAGE_TYPE)
+          : self.only;
+        criteria = { type: { $in: types } };
+      } else if (self.relatedImages) {
+        // Migrate everything except images; referenced images are added after.
+        criteria = { type: { $ne: A2_IMAGE_TYPE } };
+      }
+      const cursor = self.apos.docs.db.find(criteria).sort({
         level: 1
       });
       while (true) {
@@ -124,6 +198,9 @@ module.exports = {
 
         const [ draft ] = await self.docs.find({ _id: doc._id.replace('published', 'draft') }).toArray();
 
+        if (!draft) {
+          continue;
+        }
         if (draft.archived && (draft.parkedId !== 'archive')) {
           // Remove the published version of draft documents that are archived,
           // except the root archive page which by convention exists in the
@@ -133,12 +210,196 @@ module.exports = {
       }
     };
     self.upgradeAttachments = async () => {
-      await self.attachments.deleteMany({});
+      if (!self.merge) {
+        await self.attachments.deleteMany({});
+      }
+      const keep = self.attachmentFilter();
+      const media = self.copyMedia ? await self.prepareMediaCopy() : null;
       await self.apos.migrations.each(self.apos.attachments.db, {}, 5, async attachment => {
+        if (keep && !keep(attachment)) {
+          return;
+        }
         attachment.archivedDocIds = attachment.trashDocIds;
         delete attachment.trashDocIds;
-        await self.attachments.insertOne(attachment);
+        if (self.replace) {
+          await self.attachments.replaceOne({ _id: attachment._id }, attachment, { upsert: true });
+        } else {
+          await self.attachments.insertOne(attachment);
+        }
+        if (media) {
+          await self.copyAttachmentMedia(attachment, media);
+        }
       });
+      if (media) {
+        self.reportMediaCopy(media);
+      }
+    };
+    // Validate --a4-dir, index the source attachments directory by attachment
+    // id, and ensure the destination directory exists. Returns the context used
+    // while copying, or exits with a helpful message if the media is not where
+    // --copy-media expects it (i.e. stored locally under public/uploads).
+    self.prepareMediaCopy = async () => {
+      const rootDir = self.apos.rootDir || process.cwd();
+      const sourceDir = path.join(rootDir, 'public', 'uploads', 'attachments');
+      const destDir = path.join(self.a4Dir, 'public', 'uploads', 'attachments');
+      let dirStat = null;
+      try {
+        dirStat = await fsp.stat(self.a4Dir);
+      } catch (e) {
+        // handled below
+      }
+      if (!dirStat || !dirStat.isDirectory()) {
+        fail(`--a4-dir "${self.a4Dir}" is not an existing directory.`);
+      }
+      if (path.resolve(sourceDir) === path.resolve(destDir)) {
+        fail('--a4-dir points at the A2 project itself; there is nothing to copy.\nSpecify your new A4 project directory instead.');
+      }
+      let entries;
+      try {
+        entries = await fsp.readdir(sourceDir);
+      } catch (e) {
+        fail(`Could not read the source media directory:\n  ${sourceDir}\n${e.message}\n--copy-media only supports media stored locally under public/uploads.`);
+      }
+      // Index every file by attachment id (the portion of the filename before
+      // the first hyphen; Apostrophe ids contain no hyphens). Each attachment's
+      // original plus its scaled and cropped variants share that id prefix, so
+      // this lets us copy them all without re-deriving uploadfs paths.
+      const byId = new Map();
+      for (const file of entries) {
+        const hyphen = file.indexOf('-');
+        if (hyphen < 0) {
+          continue;
+        }
+        const id = file.slice(0, hyphen);
+        let list = byId.get(id);
+        if (!list) {
+          list = [];
+          byId.set(id, list);
+        }
+        list.push(file);
+      }
+      await fsp.mkdir(destDir, { recursive: true });
+      console.log(`Copying media from ${sourceDir}\n  to ${destDir} ...`);
+      return {
+        sourceDir,
+        destDir,
+        byId,
+        filesCopied: 0,
+        bytesCopied: 0,
+        missing: [],
+        failed: []
+      };
+    };
+    // Copy one migrated attachment's files (original, scaled sizes and crops)
+    // from the A2 uploads directory to the A4 one.
+    self.copyAttachmentMedia = async (attachment, media) => {
+      const files = media.byId.get(attachment._id);
+      if (!files || !files.length) {
+        media.missing.push(attachment._id);
+        return;
+      }
+      for (const file of files) {
+        try {
+          const from = path.join(media.sourceDir, file);
+          const to = path.join(media.destDir, file);
+          const { size } = await fsp.stat(from);
+          await fsp.copyFile(from, to);
+          media.filesCopied++;
+          media.bytesCopied += size;
+        } catch (e) {
+          media.failed.push(e);
+        }
+      }
+    };
+    self.reportMediaCopy = (media) => {
+      const mb = (media.bytesCopied / (1024 * 1024)).toFixed(1);
+      console.log(`\nCopied ${media.filesCopied} media file(s) (${mb} MB) into ${media.destDir}.`);
+      if (media.missing.length) {
+        console.log(`⚠️  ${media.missing.length} migrated attachment(s) had no files in the source directory.\nIf your A2 media is stored remotely (e.g. S3), copy it by your own means;\n--copy-media only handles media stored locally under public/uploads.`);
+      }
+      if (media.failed.length) {
+        console.log(`⚠️  ${media.failed.length} file(s) could not be copied. First error: ${media.failed[0].message}`);
+      }
+    };
+    // Returns a predicate deciding which attachments to migrate, or null to
+    // migrate all of them. An attachment's docIds/trashDocIds hold the original
+    // A2 _ids of the docs that reference it.
+    self.attachmentFilter = () => {
+      if (self.only) {
+        // Only attachments referenced by a doc we actually migrated. The keys
+        // of a2ToA4Ids are exactly those docs' A2 _ids (referenced images, if
+        // any, are in there too).
+        const migrated = new Set(self.a2ToA4Ids.keys());
+        return attachment => attachmentRefs(attachment).some(id => migrated.has(id));
+      }
+      if (self.relatedImages) {
+        // Full migration minus unreferenced images: drop an attachment only
+        // when every doc referencing it is an image we chose not to migrate.
+        const skipped = new Set(
+          [ ...self.imageA2Ids ].filter(id => !self.relatedImageA2Ids.has(id))
+        );
+        return attachment => {
+          const refs = attachmentRefs(attachment);
+          return refs.length ? refs.some(id => !skipped.has(id)) : true;
+        };
+      }
+      return null;
+    };
+    // Build the set of all A2 image doc ids (and, under workflow, a map from
+    // each to its workflowGuid) up front, and prepare the accumulator for the
+    // ids actually referenced by migrated content.
+    self.prepareRelatedImages = async () => {
+      self.imageA2Ids = new Set();
+      self.relatedImageA2Ids = new Set();
+      self.imageGuidById = new Map();
+      const workflow = self.apos.modules['apostrophe-workflow'];
+      const cursor = self.apos.docs.db.find({ type: A2_IMAGE_TYPE }).project({
+        _id: 1,
+        workflowGuid: 1
+      });
+      while (true) {
+        const doc = await cursor.next();
+        if (!doc) {
+          break;
+        }
+        self.imageA2Ids.add(doc._id);
+        if (workflow && doc.workflowGuid) {
+          self.imageGuidById.set(doc._id, doc.workflowGuid);
+        }
+      }
+    };
+    // Migrate the image docs referenced by content migrated in upgradeDocsPass.
+    self.upgradeRelatedImages = async () => {
+      if (!self.relatedImageA2Ids.size) {
+        console.log('No images are referenced by the migrated content.\n');
+        return;
+      }
+      const or = [ { _id: { $in: [ ...self.relatedImageA2Ids ] } } ];
+      // Under workflow an image exists as several docs (draft/live, per locale)
+      // sharing a workflowGuid. Bring them all, so A4 gets complete
+      // draft/published pairs rather than only the single id referenced.
+      const guids = [ ...new Set(
+        [ ...self.relatedImageA2Ids ]
+          .map(id => self.imageGuidById.get(id))
+          .filter(Boolean)
+      ) ];
+      if (guids.length) {
+        or.push({ workflowGuid: { $in: guids } });
+      }
+      const cursor = self.apos.docs.db.find({
+        type: A2_IMAGE_TYPE,
+        $or: or
+      });
+      let count = 0;
+      while (true) {
+        const doc = await cursor.next();
+        if (!doc) {
+          break;
+        }
+        await self.upgradeDoc(doc);
+        count++;
+      }
+      console.log(`Migrated ${count} referenced image doc(s), out of ${self.imageA2Ids.size} in the source.\n`);
     };
     self.fixLastPublishedAt = async () => {
       console.log('Fixing lastPublishedAt properties (may take a long time)...');
@@ -167,7 +428,15 @@ module.exports = {
         await Promise.all(promises);
       }
     };
+    self.insertOrReplaceDoc = async doc => {
+      if (self.replace) {
+        await self.docs.replaceOne({ _id: doc._id }, doc, { upsert: true });
+      } else {
+        await self.docs.insertOne(doc);
+      }
+    };
     self.upgradeDoc = async doc => {
+      const sourceType = doc.type;
       doc = await self.upgradeDocCore(doc);
       if (!doc) {
         return;
@@ -203,12 +472,17 @@ module.exports = {
       // but the type will need draft/published support in A4
       const replicateToPublished = doc._replicateToPublished;
       delete doc._replicateToPublished;
+      // Note which images this (non-image) doc references, so --related-images
+      // can migrate just those. Done here, on the fully transformed A4 doc.
+      if (self.relatedImages && (sourceType !== A2_IMAGE_TYPE)) {
+        self.collectReferencedImageIds(doc, self.imageA2Ids, self.relatedImageA2Ids);
+      }
       self.a2ToA4Ids.set(doc.a2Id, doc.aposDocId);
-      await self.docs.insertOne(doc);
+      await self.insertOrReplaceDoc(doc);
       self.docTypesFound.add(doc.type);
       self.markWidgetTypesFound(doc);
       if (replicateToPublished) {
-        await self.docs.insertOne({
+        await self.insertOrReplaceDoc({
           ...doc,
           _id: doc._id.replace(':draft', ':published'),
           aposLocale: doc.aposLocale.replace(':draft', ':published'),
@@ -527,6 +801,50 @@ module.exports = {
         }
       }
     };
+    // Record, into `found`, every id in `candidateIds` (all A2 image ids) that
+    // the migrated (A4-form) object references. Mirrors the id positions the
+    // rewrite() traversal in rewriteDocJoinIds handles — scalar id fields, the
+    // keys of id-keyed relationship maps, and rich text permalinks — with two
+    // deliberate exceptions that keep --related-images to "images A4 actually
+    // uses": an @apostrophecms/image widget counts only its imageIds (the
+    // leftover apostrophe-images pieceIds/relationships are ignored), and rich
+    // text counts only permalink targets. Keep in sync with rewrite() if the
+    // set of id positions there changes.
+    self.collectReferencedImageIds = (object, candidateIds, found) => {
+      if (object.type === '@apostrophecms/rich-text') {
+        const content = object.content || '';
+        const regexp = /apostrophe-permalink-([^"?]+)\?/g;
+        let match;
+        while ((match = regexp.exec(content))) {
+          if (candidateIds.has(match[1])) {
+            found.add(match[1]);
+          }
+        }
+        return;
+      }
+      if (object.type === '@apostrophecms/image') {
+        for (const id of (object.imageIds || [])) {
+          if (candidateIds.has(id)) {
+            found.add(id);
+          }
+        }
+        return;
+      }
+      for (const key of Object.keys(object)) {
+        if (key === 'a2Id') {
+          continue;
+        }
+        if (!Array.isArray(object) && candidateIds.has(key)) {
+          found.add(key);
+        }
+        const value = object[key];
+        if (value && ((typeof value) === 'object')) {
+          self.collectReferencedImageIds(value, candidateIds, found);
+        } else if (((typeof value) === 'string') && candidateIds.has(value)) {
+          found.add(value);
+        }
+      }
+    };
     self.report = () => {
       console.log('\nComplete!\n');
       if (self.localesFound) {
@@ -547,6 +865,12 @@ module.exports = {
 function fail(message) {
   console.error(`\n\n🛑 ${message}\n`);
   process.exit(1);
+}
+
+// The A2 _ids of every doc that references an attachment, whether live or in
+// the trash.
+function attachmentRefs(attachment) {
+  return [ ...(attachment.docIds || []), ...(attachment.trashDocIds || []) ];
 }
 
 // Log the value and return it. This is handy in


### PR DESCRIPTION
- Added the `--only=type1,type2,...` option to migrate only certain A2 doc types and the attachments they reference. Include `apostrophe-image` (and/or `apostrophe-file`) in the list if you want the corresponding media to come across.
- Added the `--related-images` option to migrate only the images actually referenced by the migrated content (one hop, resolved against the A4-form content), rather than every image. Works on its own or together with `--only`.
- Added the `--merge` option to add the upgraded content to an existing A4 database instead of insisting on `--drop`. Existing content is preserved and new content is inserted alongside it.
- Added the `--replace` option, which upserts documents and attachments (overwriting any with matching ids) rather than inserting them, so re-running an upgrade does not fail with duplicate key errors. `--replace` implies `--merge`.
- Added the `--copy-media` option (which requires `--a4-dir`) to copy the physical media files of the migrated attachments into the A4 project, respecting `--only` and `--related-images`. Assumes media is stored locally under `public/uploads/attachments`; it does not use uploadfs and so does not handle remote (e.g. S3) storage.
